### PR TITLE
Fix installation: include subpackages and declare tqdm

### DIFF
--- a/dpsynth/bin/__init__.py
+++ b/dpsynth/bin/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command-line entry points."""

--- a/dpsynth/dataset_descriptors/__init__.py
+++ b/dpsynth/dataset_descriptors/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataset descriptors bridging data formats and internal representations."""

--- a/dpsynth/eval/__init__.py
+++ b/dpsynth/eval/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tabular evaluation utilities (distribution, correlation, marginal metrics)."""

--- a/dpsynth/local_mode/__init__.py
+++ b/dpsynth/local_mode/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local (in-memory) initialization and primitives."""

--- a/dpsynth/pipeline_transformations/__init__.py
+++ b/dpsynth/pipeline_transformations/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Distributed (Beam) DP primitives, derivations, and synthesis transforms."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "apache-beam",
     "dp-accounting",
     "more-itertools",
+    "tqdm",
     "mbi @ git+https://github.com/ryan112358/mbi.git",
 ]
 dynamic = ["version"]


### PR DESCRIPTION

Fixes the two packaging issues that make `import dpsynth` fail after a clean
`pip install` (see issue: "pip install then import dpsynth fails").

### Changes

1. **Add missing `__init__.py` to subpackages.** With
   `[tool.setuptools.packages.find]` `namespaces = false`, setuptools only ships
   directories that contain an `__init__.py`. These lacked one and were dropped
   from the installed distribution, causing
   `ModuleNotFoundError: No module named 'dpsynth.pipeline_transformations'`
   (imported transitively from `dpsynth/__init__.py` →
   `data_generation_v2.py`):
   - `dpsynth/pipeline_transformations/__init__.py`
   - `dpsynth/dataset_descriptors/__init__.py`
   - `dpsynth/eval/__init__.py`
   - `dpsynth/local_mode/__init__.py`
   - `dpsynth/bin/__init__.py`

   Each file carries the standard Apache header and a one-line module docstring.

2. **Declare `tqdm`.** `discrete_mechanisms/mst.py` imports `tqdm` at module
   level; it is now listed in `[project].dependencies`.

### Verification

```console
$ pip install .
$ python -c "import dpsynth; print(dpsynth.__version__)"
0.1.0
```

`import dpsynth` and `dpsynth.generate(...)` now succeed for a non-editable
install. The change is metadata/packaging only — no runtime logic is touched.

Fixes #1
