### PR TITLE
Fix INDEPENDENT mechanism crash on duplicate cliques

### DIFF
--- a/dpsynth/discrete_mechanisms/independent.py
+++ b/dpsynth/discrete_mechanisms/independent.py
@@ -70,7 +70,13 @@ def run_mechanism(
 
   potentials = initial_potentials
   if potentials is not None:
-    potentials = potentials.expand([m.clique for m in measurements])
+    # `measurements` can contain the same clique more than once (the one-way
+    # marginals passed in via `initial_measurements` plus the one-way marginals
+    # measured in the loop above). `CliqueVector.expand` requires unique cliques
+    # and otherwise raises "Cliques must be unique.", so de-duplicate while
+    # preserving order before expanding.
+    unique_cliques = list(dict.fromkeys(m.clique for m in measurements))
+    potentials = potentials.expand(unique_cliques)
 
   model = mbi.estimation.mirror_descent(
       data.domain,

--- a/dpsynth/discrete_mechanisms/independent.py
+++ b/dpsynth/discrete_mechanisms/independent.py
@@ -70,11 +70,7 @@ def run_mechanism(
 
   potentials = initial_potentials
   if potentials is not None:
-    # `measurements` can contain the same clique more than once (the one-way
-    # marginals passed in via `initial_measurements` plus the one-way marginals
-    # measured in the loop above). `CliqueVector.expand` requires unique cliques
-    # and otherwise raises "Cliques must be unique.", so de-duplicate while
-    # preserving order before expanding.
+    # De-duplicate cliques (order-preserving); `expand` requires unique cliques.
     unique_cliques = list(dict.fromkeys(m.clique for m in measurements))
     potentials = potentials.expand(unique_cliques)
 

--- a/dpsynth/discrete_mechanisms/independent_test.py
+++ b/dpsynth/discrete_mechanisms/independent_test.py
@@ -31,6 +31,35 @@ class IndependentTest(absltest.TestCase):
       actual = synthetic.project([col]).datavector()
       np.testing.assert_allclose(actual, expected, atol=0.1)
 
+  def test_duplicate_one_way_cliques_with_initial_potentials(self):
+    # Regression test: when `initial_potentials` is provided (e.g. the empty
+    # CliqueVector for the no-constraints case) and `initial_measurements`
+    # already holds the one-way marginals, the cliques measured in the loop
+    # duplicate them. `CliqueVector.expand` rejects duplicate cliques, so the
+    # mechanism used to crash with "Cliques must be unique.".
+    domain = mbi.Domain(["a", "b", "c"], [3, 4, 5])
+    data = mbi.Dataset.synthetic(domain, N=1000)
+
+    initial_measurements = [
+        mbi.LinearMeasurement(data.project((col,)).datavector(), (col,))
+        for col in data.domain
+    ]
+    initial_potentials = mbi.CliqueVector(domain, [], {})
+
+    config = independent.IndependentConfig(pgm_iters=500)
+    synthetic = independent.run_mechanism(
+        data,
+        config,
+        zcdp_rho=10000,
+        initial_measurements=initial_measurements,
+        initial_potentials=initial_potentials,
+    )
+
+    for col in data.domain:
+      expected = data.project([col]).datavector()
+      actual = synthetic.project([col]).datavector()
+      np.testing.assert_allclose(actual, expected, atol=0.1)
+
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION

Fixes the `ValueError: Cliques must be unique.` raised when running
`dpsynth.generate(..., discrete_config=IndependentConfig())` (see issue:
"IndependentConfig synthesis raises 'Cliques must be unique.'").

### Cause

`independent.run_mechanism` builds `measurements` from `initial_measurements`
(the one-way marginals that `data_generation_v2.generate` always provides) and
then appends a freshly measured one-way marginal for every attribute, so the
list contains each one-way clique twice. When `initial_potentials` is not
`None` (e.g. the empty `CliqueVector` from `constraints.get_initial_parameters`
in the no-constraints case), `potentials.expand([m.clique for m in
measurements])` is called with duplicate cliques, which current `mbi` rejects.

### Change

De-duplicate the clique list (order-preserving) before `expand`:

```python
unique_cliques = list(dict.fromkeys(m.clique for m in measurements))
potentials = potentials.expand(unique_cliques)
```

`measurements` itself is unchanged, so the marginals fed to `mirror_descent`
and the privacy accounting are unaffected — only the clique set used to expand
the (zero) potentials is de-duplicated.

### Verification

The repro in the issue (a 2-column categorical frame with
`IndependentConfig()`) now returns a synthetic `DataFrame` instead of raising.
MST/AIM are unaffected.

Fixes #2
