### PR TITLE
[codex] fix initial measurement sigma

### DIFF
--- a/dpsynth/discrete_mechanisms/aim.py
+++ b/dpsynth/discrete_mechanisms/aim.py
@@ -199,7 +199,9 @@ class AIMMechanism(primitives.DPMechanism):
           rng,
           data,
           marginal_queries=marginal_queries,
-          gdp_sigma=zcdp_rho * self.one_way_budget_fraction,
+          gdp_sigma=accounting.zcdp_gaussian_sigma(
+              zcdp_rho * self.one_way_budget_fraction
+          ),
       )
     else:
       measurements = list(initial_measurements)


### PR DESCRIPTION
Fix AIM's direct initial one-way measurements to match the MST fix in 8ecc1a1: convert the one-way zCDP budget share to `accounting.zcdp_gaussian_sigma(...)` before passing it as `gdp_sigma` to `measure_marginals_with_noise`.

Validation: `py_compile dpsynth/discrete_mechanisms/aim.py`.
