### PR TITLE
fix docs/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,18 +195,18 @@ Both code paths support the following DP mechanisms:
 
 ## Further Documentation
 
-Detailed guides are available in the [`documentation/`](dpsynth/documentation/)
+Detailed guides are available in the [`docs/`](docs/)
 directory:
 
-*   **In-Memory DataFrame API Guide** (`documentation/in_memory_api.md`):
+*   **In-Memory DataFrame API Guide** (`docs/in_memory_api.md`):
     Detailed guide to using the Pandas-based API and local CLI.
-*   **Scalable Pipeline API Guide** (`documentation/scalable_beam_api.md`):
+*   **Scalable Pipeline API Guide** (`docs/scalable_beam_api.md`):
     Guide for distributed data generation.
-*   **Data Model & Terminology** (`documentation/data_and_terminology.md`):
+*   **Data Model & Terminology** (`docs/data_and_terminology.md`):
     Attributes, schema specifications, and `domain.yaml` format.
-*   **Processing Lifecycle** (`documentation/processing_lifecycle.md`):
+*   **Processing Lifecycle** (`docs/processing_lifecycle.md`):
     The 5-stage mathematical lifecycle shared by both code paths.
-*   **Contributor Guide** (`documentation/contributors_guide.md`):
+*   **Contributor Guide** (`docs/contributors_guide.md`):
     Architecture, PipelineBackend programming rules, and evaluation framework.
 
 *This is not an officially supported Google product. This project is

--- a/docs/in_memory_api.md
+++ b/docs/in_memory_api.md
@@ -62,7 +62,7 @@ synthetic_df = result.synthetic_data
 ## End-to-End Python Example
 
 Here is a complete Python script demonstrating how to load data, parse a domain
-YAML file, configure the AIM mechanism with a fixed random seed, and generate
+YAML file, configure the AIM mechanism, set a fixed random seed, and generate
 synthetic records.
 
 ```python
@@ -82,8 +82,7 @@ attribute_domains = domain.from_yaml_file("transaction_domain.yaml")
 synth = dpsynth.TabularSynthesizer(
     domains=attribute_domains,
     discrete_mechanism=discrete_mechanisms.AIMConfig(
-        seed=42,
-        rounds=50,
+        max_rounds=50,
         pgm_iters=1000,
     ),
 )
@@ -94,7 +93,8 @@ calibrated = synth.calibrate(
 )
 
 # 4. Generate Differentially Private synthetic data
-result = calibrated(np.random.default_rng(), sensitive_df)
+seed = 42
+result = calibrated(np.random.default_rng(seed), sensitive_df)
 synthetic_df = result.synthetic_data
 
 # 5. Save the synthetic dataframe


### PR DESCRIPTION
Fix stale README guide links and update the in-memory AIM example to use the actual `AIMConfig` fields.

Validation: checked the docs targets exist and smoke-tested `AIMConfig(max_rounds=50, pgm_iters=1000)`.
