### PR TITLE
Fix End-to-End Python Example `in_memory_api.md`

### DIFF
--- a/docs/in_memory_api.md
+++ b/docs/in_memory_api.md
@@ -82,8 +82,7 @@ attribute_domains = domain.from_yaml_file("transaction_domain.yaml")
 synth = dpsynth.TabularSynthesizer(
     domains=attribute_domains,
     discrete_mechanism=discrete_mechanisms.AIMConfig(
-        seed=42,
-        rounds=50,
+        max_rounds=50,
         pgm_iters=1000,
     ),
 )


### PR DESCRIPTION
Fix End-to-End Python Example by updating the args of AIMConfig to match API v3:
* remove `seed`
* change `rounds` to `max_rounds`